### PR TITLE
Adjust hardcoded decision policy and tier mapping to match what Demo App expects

### DIFF
--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImpl.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImpl.kt
@@ -170,8 +170,8 @@ internal class ConfigLocalDataSourceImpl @Inject constructor(
                         qualityThreshold = 0f,
                         imageSavingStrategy = FaceConfiguration.ImageSavingStrategy.NEVER,
                         decisionPolicy = DecisionPolicy(
-                            low = 1,
-                            medium = 30,
+                            low = 20,
+                            medium = 50,
                             high = 70,
                         ),
                         version = "1.0",

--- a/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/responses/AppMatchResult.kt
+++ b/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/responses/AppMatchResult.kt
@@ -18,8 +18,8 @@ data class AppMatchResult(
     // Temporarily using match confidence as a proxy for tiers.
     val tier: AppResponseTier
         get() = when (matchConfidence) {
-            AppMatchConfidence.NONE -> AppResponseTier.TIER_4
-            AppMatchConfidence.LOW -> AppResponseTier.TIER_3
+            AppMatchConfidence.NONE -> AppResponseTier.TIER_5
+            AppMatchConfidence.LOW -> AppResponseTier.TIER_4
             AppMatchConfidence.MEDIUM -> AppResponseTier.TIER_2
             AppMatchConfidence.HIGH -> AppResponseTier.TIER_1
         }


### PR DESCRIPTION
Demo app considers “Tier 4” as a “likely match”, and T3-T1 as “very likely”.

With these changes scores below 20 will be displayed as fails, 20-50 will be “likely”, and above 50 “very likely”.